### PR TITLE
Avoid defunct omxd processes and prefer mp4 streams on Youtube

### DIFF
--- a/api.pl
+++ b/api.pl
@@ -247,7 +247,7 @@ sub yt {
     if ($data) {
         my @streams = WWW::U2B::extract_streams $data->{query};
         my $streamidx;
-        for ($streamidx=0; $streamidx le $#streams; $streamidx++){
+        for ($streamidx=0; $streamidx <= $#streams; $streamidx++){
             last if $streams[$streamidx]->{type}=~/^video\/mp4/;
         }
         logger "Using stream ".$streamidx;

--- a/api.pl
+++ b/api.pl
@@ -100,6 +100,7 @@ sub status {
     } <PLAY>;
     $response->{image} = thumbnail $dir;
     print encode_json $response;
+    close PLAY;
 }
 
 # Get thumbnail image link from current playback directory
@@ -245,8 +246,13 @@ sub yt {
     # Playback command
     if ($data) {
         my @streams = WWW::U2B::extract_streams $data->{query};
-        WWW::U2B::playback "omxd $data->{cmd}", $streams[0];
-        logger "omxd $data->{cmd} $streams[0]->{url}";
+        my $streamidx;
+        for ($streamidx=0; $streamidx le $#streams; $streamidx++){
+            last if $streams[$streamidx]->{type}=~/^video\/mp4/;
+        }
+        logger "Using stream ".$streamidx;
+        WWW::U2B::playback "omxd $data->{cmd}", $streams[$streamidx];
+        logger "omxd $data->{cmd} $streams[$streamidx]->{url}";
         print header 'text/plain';
         $ytid = $data->{query};
         return;


### PR DESCRIPTION
I would like to suggest this patch which addresses two issues:
1. I see a defunct omxd process whenever the status page of remotepi is open.
2. Many youtube movies won't play with remotepi/omxd because remotepi always chooses stream 0.
Proposed solutions in this patch:
1. It closes the PLAY handle at the end of sub status to avoid defunct omxd processes
2. It looks for the first Youtube stream of type video/mp4. Many Youtube movies have stream 0 of type webm/vp8, which does not work with omxplayer (Raspberry Pi has no hardware codec for it). If no stream of type video/mp4 exists it now defaults to the last stream (not sure if that ever happens - if there is a reason to prefer first over last as failsafe stream, this can be fixed of course).

(please note this is my first attempt at forking someone else's project and creating a pull request so if I am doing something improperly please let me know).