### PR TITLE
Bug fixes: stale omxd, yt not choosing mp4, unnecesarily failing GET requests

### DIFF
--- a/api.pl
+++ b/api.pl
@@ -246,8 +246,13 @@ sub yt {
     # Playback command
     if ($data) {
         my @streams = WWW::U2B::extract_streams $data->{query};
-        WWW::U2B::playback "omxd $data->{cmd}", $streams[0];
-        logger "omxd $data->{cmd} $streams[0]->{url}";
+        foreach (@streams) {
+            next unless $_->{extension} eq 'mp4';
+            WWW::U2B::playback "omxd $data->{cmd}", $_;
+            logger "U2B: extension=".$_->{extension}.", quality=".$_->{quality};
+            logger "omxd $data->{cmd} $_->{url}";
+            last;
+        }
         print header 'text/plain';
         $ytid = $data->{query};
         return;

--- a/api.pl
+++ b/api.pl
@@ -100,6 +100,7 @@ sub status {
     } <PLAY>;
     $response->{image} = thumbnail $dir;
     print encode_json $response;
+    close PLAY;
 }
 
 # Get thumbnail image link from current playback directory

--- a/api.pl
+++ b/api.pl
@@ -38,7 +38,7 @@ while (my $cgi = new CGI::Fast) {
     my $method = request_method;
     my $data;
     if ($method eq 'POST'){
-        $data = eval { decode_json $cgi->param('POSTDATA') } if $method eq 'POST';
+        $data = eval { decode_json $cgi->param('POSTDATA') };
         if ($@) {
             print header 'text/html', '400 Malformed JSON Request';
             next;

--- a/api.pl
+++ b/api.pl
@@ -37,10 +37,12 @@ rpifm_my;
 while (my $cgi = new CGI::Fast) {
     my $method = request_method;
     my $data;
-    $data = eval { decode_json $cgi->param('POSTDATA') } if $method eq 'POST';
-    if ($@) {
-        print header 'text/html', '400 Malformed JSON Request';
-        next;
+    if ($method eq 'POST'){
+        $data = eval { decode_json $cgi->param('POSTDATA') } if $method eq 'POST';
+        if ($@) {
+            print header 'text/html', '400 Malformed JSON Request';
+            next;
+        }
     }
     my $get_req = uri_unescape $ENV{QUERY_STRING};
     if ($get_req =~ /^S/) {


### PR DESCRIPTION
I propose three bug fixes (separate commits with descriptions this time) in api.pl
1. getting rid of stale omxd processes by closing PLAY handle in sub status.
2. selecting first mp4 stream in array of youtube streams when starting playback
3. only responding with error 400 for bad POST request if $@ was actually just set by eval.

As before, feedback on content as well as form (github noob here) is appreciated.
